### PR TITLE
Add missing parameter in message

### DIFF
--- a/producer.py
+++ b/producer.py
@@ -54,13 +54,13 @@ async def main():
 
         for advise_justification in advise_justifications:
             message = advise_justification["message"]
-            justification_type = justification_type
             count = advise_justification["count"]
             try:
                 await _advise_justification.publish_to_topic(
                     _advise_justification.MessageContents(
                         message=message,
                         count=count,
+                        justification_type=justification_type,
                         component_name=COMPONENT_NAME,
                         service_version=__service_version__,
                     )


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

```
[2020-09-25 10:17:14,231] [1] [ERROR] Failed to publish with the following error message: TypeError("__init__() missing 1 required positional argument: 'justification_type'",) 
Traceback (most recent call last):
  File "/opt/app-root/src/producer.py", line 65, in main
    service_version=__service_version__,
TypeError: __init__() missing 1 required positional argument: 'justification_type'
```

## This introduces a breaking change

- [ ] Yes
- [x] No