### PR TITLE
fix accidental use of contents instead of baseMessage instance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,13 +35,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
-    hooks:
-      - id: mypy
-        exclude: '^(docs|tasks|tests)|setup\.py'
-        args: [--ignore-missing-imports]
-
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -15,3 +15,22 @@ presubmits:
             requests:
               memory: "2Gi"
               cpu: "2"
+  - name: thoth-mypy-py38
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: aicoe-ci/prow/mypy
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-pytest-py38:v0.12.6
+          command:
+            - "run-mypy"
+          args:
+            - "."
+            - "--ignore-missing-imports"
+            - "--config-file"
+            - "mypy.ini"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "200m"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+plugins = pydantic.mypy

--- a/producer.py
+++ b/producer.py
@@ -26,6 +26,7 @@ import pandas as pd
 from typing import Dict, Any, List
 
 import thoth.messaging.producer as producer
+from thoth.messaging import advise_justification_message
 from thoth.messaging.advise_justification import MessageContents as AdviseJustificationContents
 
 from thoth.report_processing.components.adviser import Adviser
@@ -265,7 +266,7 @@ def main():
         try:
             producer.publish_to_topic(
                 p,
-                AdviseJustificationContents(),
+                advise_justification_message,
                 AdviseJustificationContents.MessageContents(
                     message=message,
                     count=int(count),


### PR DESCRIPTION
Small fix to publish call && update CI files so that messaging mypy is used.
